### PR TITLE
feat: added onlyInvalidateTo prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ progress | number | null | 0 - 1
 totalProgress | number | null | 0 - 1
 playState | string | null | "play", "reverse", "pause" or "stop" possible
 disabled | boolean | null | on-the-fly (to, staggerTo) and progress, totalProgress or playState changes and are no more possible
+onlyInvalidateTo | boolean | null | on-the-fly `to` preserve the animation origin and only affect the `to` object
 [prop: string] | any | null | All other props will get merged with the vars object. So you can use for example useFrames property as prop for the Tween component instead of defining it in the from, to, staggerFrom or staggerTo objects.
 children | Node | null | Only HTML elements, [styled-components](https://www.styled-components.com/) or [React.forwardRef](https://reactjs.org/docs/forwarding-refs.html) components are getting tweened. Stateless or stateful components need to be wrapped in a HTML element.
 
@@ -210,7 +211,7 @@ class LowLevelAccess extends Component {
   componentDidMount() {
     // tween is now a TweenMax class instance
     const tween = this.tween.getGSAP();
-    
+
     // You can call any method on it
     tween.timeScale(0.5);
   }

--- a/src/Tween.js
+++ b/src/Tween.js
@@ -84,6 +84,8 @@ class Tween extends React.Component<TweenProps, {}> {
 
       disabled,
 
+      onlyInvalidateTo, // set to true in case you want to preserve the animation origin after updating the 'to' object
+
       ...vars
     } = this.props;
 
@@ -110,7 +112,12 @@ class Tween extends React.Component<TweenProps, {}> {
     // if "to" or "staggerTo" props are changed: reinit and restart tween
     if (!isEqual(to, prevProps.to)) {
       this.tween.vars = { ...to, ...vars };
-      this.tween.invalidate();
+      if( onlyInvalidateTo ) {
+        var tempProgress = this.tween.progress();
+        this.tween.progress(0).invalidate().progress(tempProgress);
+      } else {
+        this.tween.invalidate();
+      }
       if (!this.tween.paused()) {
         this.tween.restart();
       }


### PR DESCRIPTION
Closes #6.

When `onlyInvalidateTo` is set to false or nonexistent, the Tween component behaves as it did before.

However, when it is set to true, when the `to` vars change, the invalidate() call does not affect the animation origin, which means it only changes the destination of the animation.