### PR TITLE
Comparing children using fast equal check instead of just length

### DIFF
--- a/packages/react-gsap/src/Tween.tsx
+++ b/packages/react-gsap/src/Tween.tsx
@@ -109,11 +109,12 @@ class Tween extends React.Component<TweenProps, {}> {
     } = this.props;
 
     // if children change create a new tween
-    // TODO: replace easy length check with fast equal check
-    if (React.Children.count(prevProps.children) !== React.Children.count(children)) {
+    const previousChildren = React.Children.map(prevProps.children, (c: any) => c.key);
+    const currentChildren = React.Children.map(children, (c: any) => c.key);
+    if (!isEqual(previousChildren, currentChildren)) {
       this.createTween();
     }
-
+    
     if (disabled) {
       return;
     }


### PR DESCRIPTION
With previous implementation, when children changed the animation did not work. This PR fixes that.