### PR TITLE
Add missing typings of to / from with adding TweenVars

### DIFF
--- a/packages/react-gsap/src/Tween.tsx
+++ b/packages/react-gsap/src/Tween.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, ReactElement } from 'react';
 import { gsap } from 'gsap';
+import TweenVars = gsap.TweenVars;
 import { PlayState } from './types';
 import {
   getTweenFunction,
@@ -46,8 +47,8 @@ export type TweenProps = {
   target?: number | string;
   position?: string | number;
 
-  from?: any;
-  to?: any;
+  from?: TweenVars;
+  to?: TweenVars;
   stagger?: Stagger;
 
   duration?: number;


### PR DESCRIPTION
This PR adds missing typings for the `to | from` props